### PR TITLE
Add o-flexy--stretch, fix other alignment classes

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -59,6 +59,62 @@
         Flexy item
       </div>
     </div>
+
+    <hr>
+
+    <h1>Alignment</h1>
+
+    <p>Top</p>
+    <div class="o-flexy o-flexy--top">
+      <div class="o-flexy__block red">
+        <h1>Big Flexy block</h1>
+      </div>
+      <div class="o-flexy__block blue">
+        <h3>Medium Flexy block</h3>
+      </div>
+      <div class="o-flexy__block red">
+        Flexy block
+      </div>
+    </div>
+
+    <p>Middle</p>
+    <div class="o-flexy o-flexy--middle">
+      <div class="o-flexy__block red">
+        <h1>Big Flexy block</h1>
+      </div>
+      <div class="o-flexy__block blue">
+        <h3>Medium Flexy block</h3>
+      </div>
+      <div class="o-flexy__block red">
+        Flexy block
+      </div>
+    </div>
+
+    <p>Bottom</p>
+    <div class="o-flexy o-flexy--bottom">
+      <div class="o-flexy__block red">
+        <h1>Big Flexy block</h1>
+      </div>
+      <div class="o-flexy__block blue">
+        <h3>Medium Flexy block</h3>
+      </div>
+      <div class="o-flexy__block red">
+        Flexy block
+      </div>
+    </div>
+
+    <p>Stretch</p>
+    <div class="o-flexy o-flexy--stretch">
+      <div class="o-flexy__block red">
+        <h1>Big Flexy block</h1>
+      </div>
+      <div class="o-flexy__block blue">
+        <h3>Medium Flexy block</h3>
+      </div>
+      <div class="o-flexy__block red">
+        Flexy block
+      </div>
+    </div>
   </body>
 </html>
 

--- a/scss/pack/seed-flexy/_config.scss
+++ b/scss/pack/seed-flexy/_config.scss
@@ -9,5 +9,6 @@ $seed-flexy-block-namespace: #{$seed-flexy-namespace}__block !default;
 $seed-flexy-alignment: (
   top: flex-start,
   middle: center,
-  bottom: flex-end
+  bottom: flex-end,
+  stretch: stretch
 ) !default;

--- a/scss/pack/seed-flexy/objects/flexy/modifiers/_alignment.scss
+++ b/scss/pack/seed-flexy/objects/flexy/modifiers/_alignment.scss
@@ -4,9 +4,7 @@
 @import "../../../config";
 @import "pack/seed-breakpoints/_index";
 
-$__modifier-alignment-class: "#{&}-";
-
-#{$__modifier-alignment-class} {
+&- {
   @include breakpoint-prop-map($seed-flexy-alignment, (prop)) {
     align-items: prop(prop);
   }


### PR DESCRIPTION
* Stretch is a pretty useful align-items value. See the example!
* Also, all the other alignments accidentally broke. Fix em!

<img width="953" alt="screen shot 2016-08-08 at 23 22 36" src="https://cloud.githubusercontent.com/assets/68917/17498464/83b1fb06-5dbf-11e6-9f82-3c2fe4f64db0.png">
